### PR TITLE
Add short course 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 This is the repo for sketching out the initial deployment of the msc course to epimodels.dide.ic.ac.uk; once this is working we'll rewrite it to generally support a set of sites, each with their own configuration.
 
-We need to support multiple configurations easily, we currently do this with a script in the `wodin` image that can update the configurations on a volume. There are currently four sites:
+We need to support multiple configurations easily, we currently do this with a script in the `wodin` image that can update the configurations on a volume. There are currently six sites:
 
 * `config/demo`: a configuration we'll maintain to show off various wodin features
 * `config/msc-idm-2022`: the 2022 MSc course
 * `config/malawi-idm-2022`: a short course run in Malawi
 * `config/gambia-idm-2023`: a short course run in The Gambia
 * `config/acomvec-2023`: a short course run in Cameroon
+* `config/infectiousdiseasemodels-2023`: The DIDE short course (2023)
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Then deploy (or redeploy) with `./deploy`
 
 ## Adding a new site
 
-Edit [`deploy`](deploy) to:
+Edit [`sites`](sites) to:
 
 * list the new site within the array variable `SITES` (first line in the file basically)
 * add an entry in `SITES_URL` just below that; the key (in square brackets) must match the new entry in `SITES` exactly

--- a/deploy
+++ b/deploy
@@ -1,20 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-# Can do this with SITES=(config/*) but it would pick up any file
-# there too. This is the main thing to configure when adding a new
-# site (or removing one)
-SITES=(demo msc-idm-2022 malawi-idm-2022 gambia-idm-2023 acomvec-2023)
-
-declare -A SITES_URL
-declare -A SITES_REF
-
-SITES_URL[demo]="https://github.com/mrc-ide/wodin-demo-config"
-SITES_URL[msc-idm-2022]="https://github.com/mrc-ide/wodin-msc-idm-2022"
-SITES_URL[malawi-idm-2022]="https://github.com/mrc-ide/wodin-malawi-idm-2022"
-SITES_URL[gambia-idm-2023]="https://github.com/mrc-ide/wodin-gambia-idm-2023"
-SITES_URL[acomvec-2023]="https://github.com/mrc-ide/wodin-acomvec-2023"
-SITES_URL[infectiousdiseasemodels-2023]="https://github.com/mrc-ide/wodin-shortcourse-2023"
+. sites
 
 # Configure branches here
 NETWORK=epimodels

--- a/deploy
+++ b/deploy
@@ -14,6 +14,7 @@ SITES_URL[msc-idm-2022]="https://github.com/mrc-ide/wodin-msc-idm-2022"
 SITES_URL[malawi-idm-2022]="https://github.com/mrc-ide/wodin-malawi-idm-2022"
 SITES_URL[gambia-idm-2023]="https://github.com/mrc-ide/wodin-gambia-idm-2023"
 SITES_URL[acomvec-2023]="https://github.com/mrc-ide/wodin-acomvec-2023"
+SITES_URL[infectiousdiseasemodels-2023]="https://github.com/mrc-ide/wodin-shortcourse-2023"
 
 # Configure branches here
 NETWORK=epimodels

--- a/root/index.html
+++ b/root/index.html
@@ -31,6 +31,11 @@
         Infectious Disease Modelling with a focus on Malaria, run in
         Cameroon
       </li>
+      <li>
+        <a href="/infectiousdiseasemodels-2023"><code>infectiousdiseasemodels-2023</code></a>:
+        Introduction to Mathematical Models of the Epidemiology &
+        Control of Infectious Diseases (the DIDE short course), 2023
+      </li>
     </ul>
   </body>
 </html>

--- a/sites
+++ b/sites
@@ -1,0 +1,14 @@
+# Can do this with SITES=(config/*) but it would pick up any file
+# there too. This is the main thing to configure when adding a new
+# site (or removing one)
+SITES=(demo msc-idm-2022 malawi-idm-2022 gambia-idm-2023 acomvec-2023 infectiousdiseasemodels-2023)
+
+declare -A SITES_URL
+declare -A SITES_REF
+
+SITES_URL[demo]="https://github.com/mrc-ide/wodin-demo-config"
+SITES_URL[msc-idm-2022]="https://github.com/mrc-ide/wodin-msc-idm-2022"
+SITES_URL[malawi-idm-2022]="https://github.com/mrc-ide/wodin-malawi-idm-2022"
+SITES_URL[gambia-idm-2023]="https://github.com/mrc-ide/wodin-gambia-idm-2023"
+SITES_URL[acomvec-2023]="https://github.com/mrc-ide/wodin-acomvec-2023"
+SITES_URL[infectiousdiseasemodels-2023]="https://github.com/mrc-ide/wodin-shortcourse-2023"

--- a/update_source
+++ b/update_source
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eu
+
+. sites
+
+SITE=$1
+
+echo "Upating site $SITE"
+
+SITE_ARGS="/config/$SITE ${SITES_URL[$SITE]} ${SITES_REF[$SITE]:-main}"
+
+docker run --rm -v wodin-config:/config --entrypoint update-sites \
+       mrcide/wodin:main ${SITE_ARGS}


### PR DESCRIPTION
This PR adds the short course to the config and also a small utility for updating the source of a site without redeploying; this required refactoring out the sites array a bit. It's still pretty nasty because it's bash but it is what it is.

To test

```
./configure-proxy localhost
./deploy
```

this brings everything up, http://localhost/ now contains the new site to check

```
./update_source infectiousdiseasemodels-2023
```

will then refresh the source for just that site.