### PR TITLE
revert APP_PREVIEW to main

### DIFF
--- a/deploy
+++ b/deploy
@@ -6,7 +6,7 @@ set -eu
 # Configure branches here
 NETWORK=epimodels
 APP_BRANCH=main
-APP_PREVIEW=mrc-5490
+APP_PREVIEW=main
 API_BRANCH=main
 PROXY_BRANCH=main
 


### PR DESCRIPTION
The previous APP_PREVIEW branch, `mrc-5490`, is now merged and is not available on the github registry we're now using so reverting this to `main`. 

This is already tested on wodin-dev.