### PR TITLE
Add usdm-imperial-2025

### DIFF
--- a/root/index.html
+++ b/root/index.html
@@ -67,6 +67,10 @@
         <a href="/royal-society"><code>royal-society</code></a>:
         Pilot for the Royal Society
       </li>
+     <li>
+        <a href="/usdm-imperial-2025"><code>usdm-imperial-2025</code></a>:
+        University of Dar es Salaam/Imperial Modelling Workshop, 2025
+      </li>
     </ul>
   </body>
 </html>

--- a/sites
+++ b/sites
@@ -1,7 +1,7 @@
 # Can do this with SITES=(config/*) but it would pick up any file
 # there too. This is the main thing to configure when adding a new
 # site (or removing one)
-SITES=(demo msc-idm-2022 msc-idm-2023 msc-idm-2024 malawi-idm-2022 gambia-idm-2023 gambia-idm-2024 acomvec-2023 buc-2023 infectiousdiseasemodels-2023 infectiousdiseasemodels-2024 royal-society)
+SITES=(demo msc-idm-2022 msc-idm-2023 msc-idm-2024 malawi-idm-2022 gambia-idm-2023 gambia-idm-2024 acomvec-2023 buc-2023 infectiousdiseasemodels-2023 infectiousdiseasemodels-2024 royal-society usdm-imperial-2025)
 
 declare -A SITES_URL
 declare -A SITES_REF
@@ -18,3 +18,4 @@ SITES_URL[buc-2023]="https://github.com/mrc-ide/wodin-buc-2023"
 SITES_URL[infectiousdiseasemodels-2023]="https://github.com/mrc-ide/wodin-shortcourse-2023"
 SITES_URL[infectiousdiseasemodels-2024]="https://github.com/mrc-ide/wodin-shortcourse-2024"
 SITES_URL[royal-society]="https://github.com/mrc-ide/wodin-royal-society"
+SITES_URL[usdm-imperial-2025]="https://github.com/mrc-ide/usdm-imperial-2025"


### PR DESCRIPTION
Deployed onto wodin-dev at the moment (https://wodin-dev.dide.ic.ac.uk/usdm-imperial-2025/), repo is here: https://github.com/mrc-ide/usdm-imperial-2025