### PR TITLE
add Kinshasa Workshop 2026 site

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We need to support multiple configurations easily, we currently do this with a s
 * `infectiousdiseasemodels-2025`: The DIDE short course (2025)
 * `infectiousdiseasemodels-quito-2025`: The DIDE short course in Quito (2025)
 * `infectiousdiseasemodels-vietnam-2025`: a short course run in OUCRU (2025)
-* `mpox-workshop`: mpox workshop run in DRC (2026)
+* `kinshasa-workshop-2026`: a workshop run in DRC (2026)
 
 ## Deploying for the first time
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ We need to support multiple configurations easily, we currently do this with a s
 * `infectiousdiseasemodels-2025`: The DIDE short course (2025)
 * `infectiousdiseasemodels-quito-2025`: The DIDE short course in Quito (2025)
 * `infectiousdiseasemodels-vietnam-2025`: a short course run in OUCRU (2025)
+* `mpox-workshop`: mpox workshop run in DRC (2026)
 
 ## Deploying for the first time
 

--- a/root/index.html
+++ b/root/index.html
@@ -88,6 +88,10 @@
           <a href="/infectiousdiseasemodels-vietnam-2025"><code>infectiousdiseasemodels-vietnam-2025</code></a>:
           Modelling and Analysis of Serological Data - OUCRU 2025
       </li>
+      <li>
+        <a href="/mpox-workshop"><code>mpox-workshop</code></a>:
+        mpox workshop - DRC 2026
+      </li>
     </ul>
   </body>
 </html>

--- a/root/index.html
+++ b/root/index.html
@@ -89,8 +89,8 @@
           Modelling and Analysis of Serological Data - OUCRU 2025
       </li>
       <li>
-        <a href="/mpox-workshop"><code>mpox-workshop</code></a>:
-        mpox workshop - DRC 2026
+        <a href="/kinshasa-workshop-2026"><code>kinshasa-workshop-2026</code></a>:
+        Kinshasa Workshop 2026
       </li>
     </ul>
   </body>

--- a/sites
+++ b/sites
@@ -1,7 +1,7 @@
 # Can do this with SITES=(config/*) but it would pick up any file
 # there too. This is the main thing to configure when adding a new
 # site (or removing one)
-SITES=(demo msc-idm-2022 msc-idm-2023 msc-idm-2024 msc-idm-2025 malawi-idm-2022 gambia-idm-2023 gambia-idm-2024 acomvec-2023 buc-2023 infectiousdiseasemodels-2023 infectiousdiseasemodels-2024 infectiousdiseasemodels-2025 royal-society udsm-imperial-2025 infectiousdiseasemodels-quito-2025 infectiousdiseasemodels-vietnam-2025 mpox-workshop)
+SITES=(demo msc-idm-2022 msc-idm-2023 msc-idm-2024 msc-idm-2025 malawi-idm-2022 gambia-idm-2023 gambia-idm-2024 acomvec-2023 buc-2023 infectiousdiseasemodels-2023 infectiousdiseasemodels-2024 infectiousdiseasemodels-2025 royal-society udsm-imperial-2025 infectiousdiseasemodels-quito-2025 infectiousdiseasemodels-vietnam-2025 kinshasa-workshop-2026)
 
 declare -A SITES_URL
 declare -A SITES_REF
@@ -23,4 +23,4 @@ SITES_URL[royal-society]="https://github.com/mrc-ide/wodin-royal-society"
 SITES_URL[udsm-imperial-2025]="https://github.com/mrc-ide/udsm-imperial-2025"
 SITES_URL[infectiousdiseasemodels-quito-2025]="https://github.com/mrc-ide/wodin-quito-workshop"
 SITES_URL[infectiousdiseasemodels-vietnam-2025]="https://github.com/mrc-ide/infectiousdiseasemodels-vietnam-2025"
-SITES_URL[mpox-workshop]="https://github.com/mrc-ide/mpox-workshop-repo"
+SITES_URL[kinshasa-workshop-2026]="https://github.com/mrc-ide/mpox-workshop-repo"

--- a/sites
+++ b/sites
@@ -1,7 +1,7 @@
 # Can do this with SITES=(config/*) but it would pick up any file
 # there too. This is the main thing to configure when adding a new
 # site (or removing one)
-SITES=(demo msc-idm-2022 msc-idm-2023 msc-idm-2024 msc-idm-2025 malawi-idm-2022 gambia-idm-2023 gambia-idm-2024 acomvec-2023 buc-2023 infectiousdiseasemodels-2023 infectiousdiseasemodels-2024 infectiousdiseasemodels-2025 royal-society udsm-imperial-2025 infectiousdiseasemodels-quito-2025 infectiousdiseasemodels-vietnam-2025)
+SITES=(demo msc-idm-2022 msc-idm-2023 msc-idm-2024 msc-idm-2025 malawi-idm-2022 gambia-idm-2023 gambia-idm-2024 acomvec-2023 buc-2023 infectiousdiseasemodels-2023 infectiousdiseasemodels-2024 infectiousdiseasemodels-2025 royal-society udsm-imperial-2025 infectiousdiseasemodels-quito-2025 infectiousdiseasemodels-vietnam-2025 mpox-workshop)
 
 declare -A SITES_URL
 declare -A SITES_REF
@@ -23,3 +23,4 @@ SITES_URL[royal-society]="https://github.com/mrc-ide/wodin-royal-society"
 SITES_URL[udsm-imperial-2025]="https://github.com/mrc-ide/udsm-imperial-2025"
 SITES_URL[infectiousdiseasemodels-quito-2025]="https://github.com/mrc-ide/wodin-quito-workshop"
 SITES_URL[infectiousdiseasemodels-vietnam-2025]="https://github.com/mrc-ide/infectiousdiseasemodels-vietnam-2025"
+SITES_URL[mpox-workshop]="https://github.com/mrc-ide/mpox-workshop-repo"


### PR DESCRIPTION
Add new site for Kinshasa DRC workshop.

This is deployed to wodin-dev: https://wodin-dev.dide.ic.ac.uk/kinshasa-workshop-2026/