### PR TITLE
Add site for infectiousdiseasemodels-asiadenguesummit-2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ We need to support multiple configurations easily, we currently do this with a s
 * `infectiousdiseasemodels-quito-2025`: The DIDE short course in Quito (2025)
 * `infectiousdiseasemodels-vietnam-2025`: a short course run in OUCRU (2025)
 * `kinshasa-workshop-2026`: a workshop run in DRC (2026)
+* `infectiousdiseasemodels-asiadenguesummit-2026`: a workshop at 9th Asia Dengue Summit, Singapore, 15-17th June 2026
 
 ## Deploying for the first time
 

--- a/root/index.html
+++ b/root/index.html
@@ -92,6 +92,10 @@
         <a href="/kinshasa-workshop-2026"><code>kinshasa-workshop-2026</code></a>:
         Kinshasa Workshop 2026
       </li>
+      <li>
+        <a href="/infectiousdiseasemodels-asiadenguesummit-2026"><code>infectiousdiseasemodels-asiadenguesummit-2026</code></a>:
+        Infectious Disease Models Asia Dengue Summit 2026
+      </li>
     </ul>
   </body>
 </html>

--- a/sites
+++ b/sites
@@ -1,7 +1,7 @@
 # Can do this with SITES=(config/*) but it would pick up any file
 # there too. This is the main thing to configure when adding a new
 # site (or removing one)
-SITES=(demo msc-idm-2022 msc-idm-2023 msc-idm-2024 msc-idm-2025 malawi-idm-2022 gambia-idm-2023 gambia-idm-2024 acomvec-2023 buc-2023 infectiousdiseasemodels-2023 infectiousdiseasemodels-2024 infectiousdiseasemodels-2025 royal-society udsm-imperial-2025 infectiousdiseasemodels-quito-2025 infectiousdiseasemodels-vietnam-2025 kinshasa-workshop-2026)
+SITES=(demo msc-idm-2022 msc-idm-2023 msc-idm-2024 msc-idm-2025 malawi-idm-2022 gambia-idm-2023 gambia-idm-2024 acomvec-2023 buc-2023 infectiousdiseasemodels-2023 infectiousdiseasemodels-2024 infectiousdiseasemodels-2025 royal-society udsm-imperial-2025 infectiousdiseasemodels-quito-2025 infectiousdiseasemodels-vietnam-2025 kinshasa-workshop-2026 infectiousdiseasemodels-asiadenguesummit-2026)
 
 declare -A SITES_URL
 declare -A SITES_REF
@@ -24,3 +24,4 @@ SITES_URL[udsm-imperial-2025]="https://github.com/mrc-ide/udsm-imperial-2025"
 SITES_URL[infectiousdiseasemodels-quito-2025]="https://github.com/mrc-ide/wodin-quito-workshop"
 SITES_URL[infectiousdiseasemodels-vietnam-2025]="https://github.com/mrc-ide/infectiousdiseasemodels-vietnam-2025"
 SITES_URL[kinshasa-workshop-2026]="https://github.com/mrc-ide/mpox-workshop-repo"
+SITES_URL[infectiousdiseasemodels-asiadenguesummit-2026]="https://github.com/mrc-ide/infectiousdiseasemodels-asiadenguesummit-2026"


### PR DESCRIPTION
New site for workshop at 9th Asia Dengue Summit, Singapore, 15-17th June 2026

Deployed to dev site here: https://wodin-dev.dide.ic.ac.uk/infectiousdiseasemodels-asiadenguesummit-2026/