### PR TITLE
add msc 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ We need to support multiple configurations easily, we currently do this with a s
 * `infectiousdiseasemodels-vietnam-2025`: a short course run in OUCRU (2025)
 * `kinshasa-workshop-2026`: a workshop run in DRC (2026)
 * `infectiousdiseasemodels-asiadenguesummit-2026`: a workshop at 9th Asia Dengue Summit, Singapore, 15-17th June 2026
+* `msc-idm-2026`: the 2026 MSc course
 
 ## Deploying for the first time
 

--- a/root/index.html
+++ b/root/index.html
@@ -96,6 +96,10 @@
         <a href="/infectiousdiseasemodels-asiadenguesummit-2026"><code>infectiousdiseasemodels-asiadenguesummit-2026</code></a>:
         Infectious Disease Models Asia Dengue Summit 2026
       </li>
+      <li>
+        <a href="/msc-idm-2026"><code>msc-idm-2026</code></a>: the
+        2026 MSc course
+      </li>
     </ul>
   </body>
 </html>

--- a/sites
+++ b/sites
@@ -1,7 +1,7 @@
 # Can do this with SITES=(config/*) but it would pick up any file
 # there too. This is the main thing to configure when adding a new
 # site (or removing one)
-SITES=(demo msc-idm-2022 msc-idm-2023 msc-idm-2024 msc-idm-2025 malawi-idm-2022 gambia-idm-2023 gambia-idm-2024 acomvec-2023 buc-2023 infectiousdiseasemodels-2023 infectiousdiseasemodels-2024 infectiousdiseasemodels-2025 royal-society udsm-imperial-2025 infectiousdiseasemodels-quito-2025 infectiousdiseasemodels-vietnam-2025 kinshasa-workshop-2026 infectiousdiseasemodels-asiadenguesummit-2026)
+SITES=(demo msc-idm-2022 msc-idm-2023 msc-idm-2024 msc-idm-2025 malawi-idm-2022 gambia-idm-2023 gambia-idm-2024 acomvec-2023 buc-2023 infectiousdiseasemodels-2023 infectiousdiseasemodels-2024 infectiousdiseasemodels-2025 royal-society udsm-imperial-2025 infectiousdiseasemodels-quito-2025 infectiousdiseasemodels-vietnam-2025 kinshasa-workshop-2026 infectiousdiseasemodels-asiadenguesummit-2026 msc-idm-2026)
 
 declare -A SITES_URL
 declare -A SITES_REF
@@ -25,3 +25,4 @@ SITES_URL[infectiousdiseasemodels-quito-2025]="https://github.com/mrc-ide/wodin-
 SITES_URL[infectiousdiseasemodels-vietnam-2025]="https://github.com/mrc-ide/infectiousdiseasemodels-vietnam-2025"
 SITES_URL[kinshasa-workshop-2026]="https://github.com/mrc-ide/mpox-workshop-repo"
 SITES_URL[infectiousdiseasemodels-asiadenguesummit-2026]="https://github.com/mrc-ide/infectiousdiseasemodels-asiadenguesummit-2026"
+SITES_URL[msc-idm-2026]="https://github.com/mrc-ide/wodin-msc-idm-2026"


### PR DESCRIPTION
Adds the 2026 MSc site
Currently deployed to wodin-dev